### PR TITLE
sepolicy_vndr: legacy: sdm710: Fix neverallow conflict

### DIFF
--- a/legacy/vendor/sdm710/property.te
+++ b/legacy/vendor/sdm710/property.te
@@ -26,4 +26,4 @@
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #properites for init.qcom.sh script
-type vendor_media_sdm710_version_prop, property_type;
+vendor_public_prop(vendor_media_sdm710_version_prop);


### PR DESCRIPTION
This commit fixes neverallow conflict when building crDroid for sdm710 devices.